### PR TITLE
feat: Update OAuth2 callback URL scheme for driver app

### DIFF
--- a/src/main/java/capston2024/bustracker/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/capston2024/bustracker/handler/OAuth2LoginSuccessHandler.java
@@ -27,8 +27,8 @@ public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
     private final TokenService tokenService;
 
     // 앱 스킴 URL
-
-    // 여기에 버스기사 앱 스킴 URL 포함할 것 @엄지석
+    private static final String DRIVER_IOS_APP_SCHEME_URL = "com.driver://auth/oauth2callback";
+    private static final String DRIVER_ANDROID_APP_SCHEME_URL = "com.driver://auth/oauth2callback";
     private static final String IOS_APP_SCHEME_URI = "org.reactjs.native.example.Busbuddybuddy://oauth2callback";
     private static final String ANDROID_APP_SCHEME_URI = "com.busbuddybuddy://oauth2callback";
     private static final long REFRESH_TOKEN_ROTATION_TIME = 1000 * 60 * 60 * 24 * 7L;


### PR DESCRIPTION
- Update iOS and Android app scheme URLs to 'com.driver://auth/oauth2callback'
- Standardize callback URL format across platforms
- Remove legacy Busbuddybuddy app scheme references