### PR TITLE
refactor: Driver 도메인 분리 및 전용 Repository 구현

### DIFF
--- a/src/main/java/capston2024/bustracker/controller/DriverController.java
+++ b/src/main/java/capston2024/bustracker/controller/DriverController.java
@@ -2,8 +2,7 @@ package capston2024.bustracker.controller;
 
 import capston2024.bustracker.config.dto.ApiResponse;
 import capston2024.bustracker.config.dto.LicenseVerifyRequestDto;
-import capston2024.bustracker.config.status.Role;
-import capston2024.bustracker.domain.User;
+import capston2024.bustracker.domain.Driver;
 import capston2024.bustracker.exception.BusinessException;
 import capston2024.bustracker.exception.ResourceNotFoundException;
 import capston2024.bustracker.exception.UnauthorizedException;
@@ -16,7 +15,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.core.user.OAuth2User;
-import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -98,7 +96,7 @@ public class DriverController {
      */
     @GetMapping
     @PreAuthorize("hasRole('STAFF')")
-    public ResponseEntity<ApiResponse<List<User>>> getDriversByOrganization(
+    public ResponseEntity<ApiResponse<List<Driver>>> getDriversByOrganization(
             @AuthenticationPrincipal OAuth2User principal) {
 
         log.info("조직별 기사 목록 조회 요청");
@@ -122,7 +120,7 @@ public class DriverController {
             throw new BusinessException("조직에 속하지 않은 사용자는 기사 정보를 조회할 수 없습니다.");
         }
 
-        List<User> drivers = driverService.getDriversByOrganizationId(organizationId);
+        List<Driver> drivers = driverService.getDriversByOrganizationId(organizationId);
 
         return ResponseEntity.ok(new ApiResponse<>(drivers,
                 String.format("조직의 모든 기사가 성공적으로 조회되었습니다. (총 %d명)", drivers.size())));
@@ -133,7 +131,7 @@ public class DriverController {
      */
     @GetMapping("/{id}")
     @PreAuthorize("hasRole('STAFF')")
-    public ResponseEntity<ApiResponse<User>> getDriverById(
+    public ResponseEntity<ApiResponse<Driver>> getDriverById(
             @PathVariable String id,
             @AuthenticationPrincipal OAuth2User principal) {
 
@@ -158,7 +156,7 @@ public class DriverController {
             throw new BusinessException("조직에 속하지 않은 사용자는 기사 정보를 조회할 수 없습니다.");
         }
 
-        User driver = driverService.getDriverByIdAndOrganizationId(id, organizationId);
+        Driver driver = driverService.getDriverByIdAndOrganizationId(id, organizationId);
 
         return ResponseEntity.ok(new ApiResponse<>(driver, "기사 정보가 성공적으로 조회되었습니다."));
     }

--- a/src/main/java/capston2024/bustracker/domain/Driver.java
+++ b/src/main/java/capston2024/bustracker/domain/Driver.java
@@ -21,14 +21,36 @@ public class Driver {
     private String role = "DRIVER";
     private String organizationId;
 
-    // Personal information
+    // Location information
+    private Location location;
+
+    // Personal information (RSA 암호화 필요)
     private String identity; // 주민등록번호
     private String birthDate;
     private String phoneNumber;
 
-    // License information
+    // License information (RSA 암호화 필요)
     private String licenseNumber;
     private String licenseSerial;
     private String licenseType;
     private String licenseExpiryDate;
+
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Location {
+        private double[] coordinates; // [경도, 위도]
+
+        public double getLongitude() {
+            return coordinates != null && coordinates.length > 0 ? coordinates[0] : 0.0;
+        }
+
+        public double getLatitude() {
+            return coordinates != null && coordinates.length > 1 ? coordinates[1] : 0.0;
+        }
+
+        public void setCoordinates(double longitude, double latitude) {
+            this.coordinates = new double[]{longitude, latitude};
+        }
+    }
 }

--- a/src/main/java/capston2024/bustracker/repository/DriverRepository.java
+++ b/src/main/java/capston2024/bustracker/repository/DriverRepository.java
@@ -1,0 +1,47 @@
+package capston2024.bustracker.repository;
+
+import capston2024.bustracker.domain.Driver;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Driver 엔티티를 위한 Repository
+ * Auth 컬렉션에서 role이 'DRIVER'인 문서만 조회
+ */
+@Repository
+public interface DriverRepository extends MongoRepository<Driver, String> {
+
+    /**
+     * 이메일로 드라이버 조회
+     */
+    @Query("{'email': ?0, 'role': 'DRIVER'}")
+    Optional<Driver> findByEmail(String email);
+
+    /**
+     * 조직별 모든 드라이버 조회
+     */
+    @Query("{'organizationId': ?0, 'role': 'DRIVER'}")
+    List<Driver> findByOrganizationId(String organizationId);
+
+    /**
+     * ID와 조직으로 드라이버 조회
+     */
+    @Query("{'_id': ?0, 'organizationId': ?1, 'role': 'DRIVER'}")
+    Optional<Driver> findByIdAndOrganizationId(String id, String organizationId);
+
+    /**
+     * 운전면허 번호로 드라이버 조회
+     */
+    @Query("{'licenseNumber': ?0, 'role': 'DRIVER'}")
+    Optional<Driver> findByLicenseNumber(String licenseNumber);
+
+    /**
+     * 조직과 운전면허 번호로 드라이버 존재 여부 확인
+     */
+    @Query(value = "{'organizationId': ?0, 'licenseNumber': ?1, 'role': 'DRIVER'}", exists = true)
+    boolean existsByOrganizationIdAndLicenseNumber(String organizationId, String licenseNumber);
+}


### PR DESCRIPTION
- DriverRepository 생성으로 Auth 컬렉션에서 role='DRIVER' 데이터만 조회
- Driver 도메인 모델에 location 필드 추가 (coordinates 배열 구조)
- 모든 드라이버 API의 리턴 타입을 User → Driver로 변경
- NoSQL 특성을 활용한 도메인별 데이터 모델링 구현